### PR TITLE
Switch to DeepSeek model with GPU support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,14 @@ services:
     volumes:
       - ./orchestrator/outputs:/outputs
     environment:
-      - MODEL_ID=facebook/opt-1.3b
+      - MODEL_ID=deepseek-ai/deepseek-r1-distill-qwen-14b
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
 
   tts:
     image: synesthesiam/opentts:latest

--- a/services/llm_server/README.md
+++ b/services/llm_server/README.md
@@ -1,0 +1,20 @@
+# LLM Server
+
+This directory documents how to run the HuggingFace Text Generation Inference container used in `docker-compose.yml`.
+
+## Model Weights
+The compose file sets the environment variable `MODEL_ID=deepseek-ai/deepseek-r1-distill-qwen-14b`. When the container starts, it will download this model from HuggingFace. To reuse weights across container restarts or provide your own copy of the model, mount a host directory and set `HF_HOME` accordingly:
+
+```yaml
+services:
+  llm:
+    volumes:
+      - /path/to/hf_cache:/data
+    environment:
+      - HF_HOME=/data
+```
+
+If the model requires authentication, supply `HUGGING_FACE_HUB_TOKEN` in the environment.
+
+## GPU Access
+GPU usage is configured via `docker-compose.yml` using `deploy.resources.reservations.devices` so Docker will allocate available GPUs when the container runs.


### PR DESCRIPTION
## Summary
- switch default MODEL_ID to `deepseek-ai/deepseek-r1-distill-qwen-14b`
- add GPU reservation in the compose file
- document LLM server environment variables and volume mounts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864eb0aaee88327b4c5198227c9bb65