### PR TITLE
Align defaults with compose ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This project demonstrates a simple orchestration of a text generation model and 
 
 ### Orchestrator
 - **`/generate_story`**
-  - **URL**: `http://localhost:8000/generate_story`
+  - **URL**: `http://localhost:8080/generate_story`
   - **Method**: `POST`
   - **Example payload**:
     ```json
@@ -52,7 +52,7 @@ This project demonstrates a simple orchestration of a text generation model and 
     ```
   - Returns JSON containing the generated story text.
 - **`/speak`**
-  - **URL**: `http://localhost:50021/speak`
+  - **URL**: `http://localhost:5500/speak`
   - **Method**: `POST`
   - **Example payload**:
     ```json
@@ -60,7 +60,7 @@ This project demonstrates a simple orchestration of a text generation model and 
     ```
   - Returns the audio bytes of the spoken text.
 - **`/story`**
-  - **URL**: `http://localhost:8000/story`
+  - **URL**: `http://localhost:8080/story`
   - **Method**: `POST`
   - **Example payload**:
     ```json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.8'
 services:
   llm:
     image: huggingface/text-generation-inference:latest
+    # Exposes the LLM server on http://localhost:8080
     ports:
       - "8080:80"
     volumes:
@@ -19,6 +20,7 @@ services:
 
   tts:
     image: synesthesiam/opentts:latest
+    # Exposes the TTS server on http://localhost:5500
     ports:
       - "5500:5500"
     volumes:

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -86,8 +86,8 @@ app = FastAPI()
 
 @app.post("/story")
 def create_story(request: StoryRequest):
-    llm_url = os.environ.get("LLM_SERVER_URL", "http://localhost:8000")
-    tts_url = os.environ.get("TTS_SERVER_URL", "http://localhost:50021")
+    llm_url = os.environ.get("LLM_SERVER_URL", "http://localhost:8080")
+    tts_url = os.environ.get("TTS_SERVER_URL", "http://localhost:5500")
     try:
         md_path, audio_path = run_story(
             prompt=request.prompt,


### PR DESCRIPTION
## Summary
- update default ports in CLI and FastAPI for orchestrator
- document ports explicitly in `docker-compose.yml`
- update README examples to use port 8080/5500

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6864f033de308327adf720125f3b864d