### PR TITLE
Add voice configuration for OpenTTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ This project demonstrates a simple orchestration of a text generation model and 
 - **Method**: `POST`
 - **Example payload**:
   ```json
-  {"text": "Hello world", "speaker": "en"}
+  {"text": "Hello world", "speaker": "coqui"}
   ```
   The service returns an audio file containing the spoken text.
+  Available voices are defined in `services/tts_server/voices.yml`. This
+  repository includes voices for Coqui TTS and Suno Bark. Select the desired
+  voice by passing its name as the `speaker` value when calling the API.
 
 ### Orchestrator
 - **`/generate_story`**
@@ -81,7 +84,8 @@ Audio saved to orchestrator/outputs/my-story/story.mp3
 
 ## Directory Structure
 - `services/llm_server` – placeholder for custom TGI configuration.
-- `services/tts_server` – placeholder for custom OpenTTS configuration.
+- `services/tts_server` – OpenTTS settings including `voices.yml` defining the
+  available speakers.
 - `orchestrator/templates` – optional templates for prompts or TTS scripts.
 - `orchestrator/outputs` – location of saved outputs from both services.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,7 @@ services:
       - "5500:5500"
     volumes:
       - ./orchestrator/outputs:/outputs
+      - ./services/tts_server/voices.yml:/config/voices.yml:ro
+    environment:
+      - VOICE_CONFIG=/config/voices.yml
+

--- a/services/tts_server/voices.yml
+++ b/services/tts_server/voices.yml
@@ -1,0 +1,5 @@
+voices:
+  - id: coqui
+    description: "English voice provided by Coqui TTS"
+  - id: bark
+    description: "English voice provided by Suno Bark"


### PR DESCRIPTION
## Summary
- add `services/tts_server/voices.yml` listing desired voices
- mount the voice list into the OpenTTS container via `docker-compose.yml`
- document available voices and how to select them in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6864f20a13b883279f9b0631a9540fef