### PR TITLE
Align orchestrator with backend APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,6 @@ This project demonstrates a simple orchestration of a text generation model and 
   voice by passing its name as the `speaker` value when calling the API.
 
 ### Orchestrator
-- **`/generate_story`**
-  - **URL**: `http://localhost:8080/generate_story`
-  - **Method**: `POST`
-  - **Example payload**:
-    ```json
-    {"prompt": "Tell me a bedtime story about a cat"}
-    ```
-  - Returns JSON containing the generated story text.
-- **`/speak`**
-  - **URL**: `http://localhost:5500/speak`
-  - **Method**: `POST`
-  - **Example payload**:
-    ```json
-    {"text": "Once upon a time", "language": "en"}
-    ```
-  - Returns the audio bytes of the spoken text.
 - **`/story`**
   - **URL**: `http://localhost:8080/story`
   - **Method**: `POST`

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -132,7 +132,7 @@ def test_pipeline(tmp_path, llm_server, tts_server):
         out_dir = _run_pipeline(tmp_path, f"Prompt {lang}", lang, llm_server, tts_url)
         output_dirs.append(out_dir)
 
-    assert [r["language"] for r in requests_data] == languages
+    assert [r["speaker"] for r in requests_data] == languages
 
     for dir_ in output_dirs:
         md = dir_ / "story.md"


### PR DESCRIPTION
## Summary
- call backend services using `/generate` and `/api/tts`
- make FastAPI optional so tests can run without installing dependencies
- save outputs relative to the current working directory
- update docs to remove unused endpoints
- adjust tests for new request payload

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864fe0054a48327839d329708f59bd7