### PR TITLE
Add Kokoro TTS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The same functionality is available from the command line. Provide the prompt,
 language and style as positional arguments:
 
 ```bash
-python -m orchestrator.main "A brave knight" en epic --llm-url http://localhost:8080 --tts-url http://localhost:5500
+python -m orchestrator.main "A brave knight" en epic --llm-url http://localhost:8080 --tts-url http://localhost:5500 --tts-engine opentts
 ```
 
 Each run creates a folder under `orchestrator/outputs/{slug}/` containing
@@ -71,7 +71,9 @@ Each run creates a folder under `orchestrator/outputs/{slug}/` containing
   basic `coqui` and `bark` voices, you can select gender-specific options such
   as `coqui-female-1`, `coqui-female-2`, `bark-female`, `coqui-male-1`,
   `coqui-male-2`, and `bark-male`. Choose one of these IDs by passing it as the
-  `speaker` value when calling the API.
+  `speaker` value when calling the API. The orchestrator also supports a
+  separate Kokoro engine by passing `--tts-engine kokoro` (or `tts_engine` in the
+  API), which targets the `/api/kokoro` endpoint.
 
 #### Available Voices
 The following voice IDs are defined in `services/tts_server/voices.yml`.
@@ -83,6 +85,7 @@ The following voice IDs are defined in `services/tts_server/voices.yml`.
 **Male**
 
 - `bark` – English voice provided by Suno Bark
+- `kokoro` – Japanese voice provided by Kokoro TTS
 
 Example using the `bark` voice:
 

--- a/services/tts_server/voices.yml
+++ b/services/tts_server/voices.yml
@@ -15,3 +15,5 @@ voices:
     description: "English male voice using Coqui model 2"
   - id: bark-male
     description: "English male voice using Suno Bark"
+  - id: kokoro
+    description: "Japanese voice provided by Kokoro TTS"


### PR DESCRIPTION
## Summary
- integrate optional Kokoro engine
- expose `--tts-engine` CLI flag and API parameter
- record request path in test TTS server
- add Kokoro voice entry
- test Kokoro pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686526abb3ac8327991be19e4f435a79