### PR TITLE
Add Wikipedia-based location context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CGAIV2
 
-This project demonstrates a simple orchestration of a text generation model and text-to-speech service. The provided `docker-compose.yml` launches two containers: HuggingFace TGI for language generation and OpenTTS for speech synthesis. Outputs are stored under `orchestrator/outputs` so that generated text or audio files persist on the host.
+This project demonstrates a simple orchestration of a text generation model and text-to-speech service. The provided `docker-compose.yml` launches two containers: HuggingFace TGI for language generation and OpenTTS for speech synthesis. Outputs are stored under `orchestrator/outputs` so that generated text or audio files persist on the host. The tool can optionally fetch background information about a location from Wikipedia before generating text.
 
 ## Setup
 1. Install [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/).
@@ -42,7 +42,7 @@ The same functionality is available from the command line. Provide the prompt,
 language and style as positional arguments:
 
 ```bash
-python -m orchestrator.main "A brave knight" en epic --llm-url http://localhost:8080 --tts-url http://localhost:5500 --tts-engine opentts
+python -m orchestrator.main "A brave knight" en epic --llm-url http://localhost:8080 --tts-url http://localhost:5500 --tts-engine opentts --location "Paris"
 ```
 
 Each run creates a folder under `orchestrator/outputs/{slug}/` containing
@@ -104,7 +104,7 @@ curl -X POST http://localhost:5500/api/tts \
   - **Method**: `POST`
   - **Example payload**:
     ```json
-    {"prompt": "A brave knight", "language": "en", "style": "epic"}
+    {"prompt": "A brave knight", "language": "en", "style": "epic", "location": "Paris"}
     ```
   - Runs the full workflow and saves the results to `orchestrator/outputs/{slug}/`.
 

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -4,6 +4,7 @@ import re
 from pathlib import Path
 
 import requests
+from .sources import fetch_wikipedia_extract
 
 try:
     from fastapi import FastAPI, HTTPException
@@ -35,9 +36,13 @@ def run_story(
     llm_url: str,
     tts_url: str,
     tts_engine: str = "opentts",
+    location: str | None = None,
     output_base_dir: Path | str | None = None,
 ):
     template = load_template()
+    if location:
+        info = fetch_wikipedia_extract(location)
+        prompt = f"{prompt}\n\n{info}"
     formatted_prompt = template.format(prompt=prompt, language=language, style=style)
 
     llm_response = requests.post(
@@ -77,6 +82,10 @@ def main():
     parser.add_argument("language", help="Language for the story")
     parser.add_argument("style", help="Story style")
     parser.add_argument(
+        "--location",
+        help="Location to fetch context from using open data",
+    )
+    parser.add_argument(
         "--llm-url",
         default=os.environ.get("LLM_SERVER_URL", "http://localhost:8080"),
         help="Base URL of LLM server",
@@ -101,6 +110,7 @@ def main():
         llm_url=args.llm_url,
         tts_url=args.tts_url,
         tts_engine=args.tts_engine,
+        location=args.location,
     )
 
     print(f"Markdown saved to {md_path}")
@@ -112,6 +122,7 @@ class StoryRequest(BaseModel):
     language: str
     style: str
     tts_engine: str = "opentts"
+    location: str | None = None
 
 
 if FastAPI is not None:
@@ -130,6 +141,7 @@ if FastAPI is not None:
                 llm_url=llm_url,
                 tts_url=tts_url,
                 tts_engine=tts_engine,
+                location=request.location,
             )
         except requests.RequestException as exc:
             raise HTTPException(status_code=502, detail=str(exc))

--- a/orchestrator/sources.py
+++ b/orchestrator/sources.py
@@ -1,0 +1,11 @@
+import requests
+from urllib.parse import quote
+
+
+def fetch_wikipedia_extract(title: str) -> str:
+    """Return summary extract for a Wikipedia page title."""
+    url = f"https://en.wikipedia.org/api/rest_v1/page/summary/{quote(title)}"
+    resp = requests.get(url, headers={"Accept": "application/json"})
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("extract", "")

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+import types
+
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo_root))
+
+requests_stub = types.SimpleNamespace()
+def _fake_get(url, headers=None):
+    raise AssertionError("should be patched")
+requests_stub.get = _fake_get
+sys.modules['requests'] = requests_stub
+
+from orchestrator import sources
+
+
+def test_fetch_wikipedia_extract(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers=None):
+        captured['url'] = url
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {'extract': 'Info about place'}
+        return Resp()
+
+    monkeypatch.setattr(sources.requests, 'get', fake_get)
+    result = sources.fetch_wikipedia_extract('Berlin')
+    assert 'Berlin' in captured['url']
+    assert result == 'Info about place'


### PR DESCRIPTION
## Summary
- enrich prompt with location data fetched from Wikipedia
- add `--location` CLI option and API field for optional location
- document new option in README
- cover new functionality with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865354b7b508327967ae660c031684c