### PR TITLE
Fix README Orchestrator section

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ curl -X POST http://localhost:5500/api/tts \
 
 ### Orchestrator
 
-### Orchestrator
 - **`/story`**
   - **URL**: `http://localhost:8000/story`
   - **Method**: `POST`


### PR DESCRIPTION
## Summary
- remove duplicate "### Orchestrator" heading in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653bfd120c83278d3f37924eb27867