### PR TITLE
Add login with token auth for story endpoint

### DIFF
--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -2,16 +2,20 @@ import argparse
 import os
 import re
 from pathlib import Path
+from datetime import datetime, timedelta
+import secrets
 
 import requests
 from .sources import fetch_wikipedia_extract, fetch_wikivoyage_extract
 
 try:
-    from fastapi import FastAPI, HTTPException
+    from fastapi import FastAPI, HTTPException, Header, Depends
     from pydantic import BaseModel
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     FastAPI = None
     HTTPException = Exception
+    Header = lambda *a, **k: None  # type: ignore[misc]
+    Depends = lambda x: None  # type: ignore[misc]
 
     class BaseModel:  # pragma: no cover - minimal stub
         pass
@@ -129,11 +133,45 @@ class StoryRequest(BaseModel):
     location: str | None = None
 
 
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+TOKEN_TTL = timedelta(minutes=5)
+TOKENS: dict[str, datetime] = {}
+
+
+def _generate_token() -> str:
+    token = secrets.token_hex(16)
+    TOKENS[token] = datetime.utcnow() + TOKEN_TTL
+    return token
+
+
+def verify_token(token: str) -> None:
+    expiry = TOKENS.get(token)
+    if not expiry or expiry < datetime.utcnow():
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+
+def require_token(x_token: str = Header(..., alias="X-Token")) -> str:  # pragma: no cover - simple dependency
+    verify_token(x_token)
+    return x_token
+
+
 if FastAPI is not None:
     app = FastAPI()
 
+    @app.post("/login")
+    def login(request: LoginRequest):
+        user = os.environ.get("API_USERNAME", "admin")
+        pw = os.environ.get("API_PASSWORD", "password")
+        if request.username == user and request.password == pw:
+            return {"token": _generate_token()}
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
     @app.post("/story")
-    def create_story(request: StoryRequest):
+    def create_story(request: StoryRequest, token: str = Depends(require_token)):
         llm_url = os.environ.get("LLM_SERVER_URL", "http://localhost:8080")
         tts_url = os.environ.get("TTS_SERVER_URL", "http://localhost:5500")
         tts_engine = os.environ.get("TTS_ENGINE", request.tts_engine)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,52 @@
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+
+def _get_app(monkeypatch):
+    monkeypatch.setenv("API_USERNAME", "alice")
+    monkeypatch.setenv("API_PASSWORD", "secret")
+    import orchestrator.main as main
+    importlib.reload(main)
+    monkeypatch.setattr(main, "run_story", lambda **kwargs: (Path("story.md"), Path("story.mp3")))
+    return main.app
+
+
+def test_login_success(monkeypatch):
+    app = _get_app(monkeypatch)
+    client = TestClient(app)
+    resp = client.post("/login", json={"username": "alice", "password": "secret"})
+    assert resp.status_code == 200
+    assert "token" in resp.json()
+
+
+def test_login_failure(monkeypatch):
+    app = _get_app(monkeypatch)
+    client = TestClient(app)
+    resp = client.post("/login", json={"username": "alice", "password": "bad"})
+    assert resp.status_code == 401
+
+
+def test_story_requires_token(monkeypatch):
+    app = _get_app(monkeypatch)
+    client = TestClient(app)
+    login = client.post("/login", json={"username": "alice", "password": "secret"})
+    token = login.json()["token"]
+    resp = client.post(
+        "/story",
+        json={"prompt": "p", "language": "en", "style": "fun"},
+        headers={"X-Token": token},
+    )
+    assert resp.status_code == 200
+
+    resp2 = client.post(
+        "/story",
+        json={"prompt": "p", "language": "en", "style": "fun"},
+        headers={"X-Token": "wrong"},
+    )
+    assert resp2.status_code == 401


### PR DESCRIPTION
## Summary
- secure story generation API by adding a login route
- require a short-lived token on `/story`
- create a small FastAPI auth test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654512c4bc8327bdc506af12b0d32a