### PR TITLE
Add web GUI served via FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ uvicorn orchestrator.main:app
 ```
 
 The server listens on `http://127.0.0.1:8000` by default. Use the `/story`
-endpoint described below to generate stories.
+endpoint described below to generate stories. Open `http://127.0.0.1:8000/` in a
+browser to use a simple HTML interface.
 
 ### CLI
 The same functionality is available from the command line. Provide the prompt,

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -8,15 +8,21 @@ from .sources import fetch_wikipedia_extract, fetch_wikivoyage_extract
 
 try:
     from fastapi import FastAPI, HTTPException
+    from fastapi.responses import FileResponse
+    from fastapi.staticfiles import StaticFiles
     from pydantic import BaseModel
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     FastAPI = None
     HTTPException = Exception
+    FileResponse = None
+    StaticFiles = None
 
-    class BaseModel:  # pragma: no cover - minimal stub
-        pass
+class BaseModel:  # pragma: no cover - minimal stub
+    pass
 
-TEMPLATE_PATH = Path(__file__).resolve().parent / "templates" / "story_prompt.txt"
+TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
+OUTPUTS_DIR = Path(__file__).resolve().parent / "outputs"
+TEMPLATE_PATH = TEMPLATE_DIR / "story_prompt.txt"
 
 def slugify(value: str) -> str:
     value = value.lower()
@@ -131,6 +137,11 @@ class StoryRequest(BaseModel):
 
 if FastAPI is not None:
     app = FastAPI()
+    app.mount("/outputs", StaticFiles(directory=OUTPUTS_DIR), name="outputs")
+
+    @app.get("/")
+    def read_index():
+        return FileResponse(TEMPLATE_DIR / "index.html")
 
     @app.post("/story")
     def create_story(request: StoryRequest):

--- a/orchestrator/templates/index.html
+++ b/orchestrator/templates/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Story Generator</title>
+</head>
+<body>
+    <h1>Story Generator</h1>
+    <form id="storyForm">
+        <label>
+            Prompt:
+            <input type="text" id="prompt" required>
+        </label>
+        <br>
+        <label>
+            Location:
+            <input type="text" id="location">
+        </label>
+        <br>
+        <label>
+            Language:
+            <input type="text" id="language" value="English" required>
+        </label>
+        <br>
+        <label>
+            Style:
+            <input type="text" id="style" value="fun" required>
+        </label>
+        <br>
+        <label>
+            TTS Engine:
+            <select id="tts_engine">
+                <option value="opentts">OpenTTS</option>
+                <option value="kokoro">Kokoro</option>
+            </select>
+        </label>
+        <br>
+        <button type="submit">Generate</button>
+    </form>
+
+    <div id="result" style="display: none;">
+        <pre id="storyText"></pre>
+        <audio id="storyAudio" controls></audio>
+    </div>
+
+    <script>
+    document.getElementById('storyForm').addEventListener('submit', async function(e) {
+        e.preventDefault();
+        const payload = {
+            prompt: document.getElementById('prompt').value,
+            language: document.getElementById('language').value,
+            style: document.getElementById('style').value,
+            location: document.getElementById('location').value || null,
+            tts_engine: document.getElementById('tts_engine').value
+        };
+        const resp = await fetch('/story', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+        if (!resp.ok) {
+            alert('Error: ' + await resp.text());
+            return;
+        }
+        const data = await resp.json();
+        const outputPrefix = '/outputs/';
+        const mdPath = data.markdown.substring(data.markdown.indexOf('outputs/'));
+        const audioPath = data.audio.substring(data.audio.indexOf('outputs/'));
+        const textResp = await fetch('/' + mdPath);
+        document.getElementById('storyText').textContent = await textResp.text();
+        document.getElementById('storyAudio').src = '/' + audioPath;
+        document.getElementById('result').style.display = 'block';
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` with a simple form and JavaScript client
- mount the outputs folder and serve `index.html` from the FastAPI app
- document the HTML interface in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686545171fbc832788f22e77d1891f2e