### PR TITLE
Fix FastAPI imports and update test stubs

### DIFF
--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -11,15 +11,21 @@ from .sources import fetch_wikipedia_extract, fetch_wikivoyage_extract
 
 try:
     from fastapi import FastAPI, HTTPException, Header, Depends
+    from fastapi.responses import FileResponse
+    from fastapi.staticfiles import StaticFiles
     from pydantic import BaseModel
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     FastAPI = None
     HTTPException = Exception
     Header = lambda *a, **k: None  # type: ignore[misc]
     Depends = lambda x: None  # type: ignore[misc]
+    FileResponse = None
+    StaticFiles = None
 
-class BaseModel:  # pragma: no cover - minimal stub
-    pass
+    class BaseModel:  # pragma: no cover - minimal stub
+        def __init__(self, **data: object) -> None:
+            for k, v in data.items():
+                setattr(self, k, v)
 
 TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
 OUTPUTS_DIR = Path(__file__).resolve().parent / "outputs"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -79,16 +79,51 @@ def post(url, json=None):
 
     # create stub fastapi and pydantic modules
     fastapi_mod = types.ModuleType("fastapi")
+
     class FastAPI:
         def __init__(self):
             self.endpoint = None
+
         def post(self, path):
             def decorator(fn):
                 self.endpoint = fn
                 return fn
             return decorator
+
+        def get(self, path):
+            def decorator(fn):
+                return fn
+            return decorator
+
+        def mount(self, *args, **kwargs):
+            pass
+
+    def Header(*args, **kwargs):
+        return None
+
+    def Depends(dep):
+        return None
+
+    class StaticFiles:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    def FileResponse(*args, **kwargs):
+        return None
+
     fastapi_mod.FastAPI = FastAPI
     fastapi_mod.HTTPException = Exception
+    fastapi_mod.Header = Header
+    fastapi_mod.Depends = Depends
+    fastapi_mod.StaticFiles = StaticFiles
+    fastapi_mod.FileResponse = FileResponse
+
+    responses_mod = types.ModuleType("fastapi.responses")
+    responses_mod.FileResponse = FileResponse
+    staticfiles_mod = types.ModuleType("fastapi.staticfiles")
+    staticfiles_mod.StaticFiles = StaticFiles
+    fastapi_mod.responses = responses_mod
+    fastapi_mod.staticfiles = staticfiles_mod
 
     pyd_mod = types.ModuleType("pydantic")
     class BaseModel:
@@ -99,6 +134,8 @@ def post(url, json=None):
 
     sys.modules.pop("requests", None)
     sys.modules["fastapi"] = fastapi_mod
+    sys.modules["fastapi.responses"] = responses_mod
+    sys.modules["fastapi.staticfiles"] = staticfiles_mod
     sys.modules["pydantic"] = pyd_mod
 
     repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- import `FileResponse` and `StaticFiles` in orchestrator
- adjust fallback BaseModel to accept keyword data
- extend FastAPI test stub with missing functions and submodules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654d23778083279c3eed249e25122a