### PR TITLE
Update default output directory

### DIFF
--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -69,7 +69,11 @@ def run_story(
     story_text = llm_response.json().get("story") or llm_response.text
 
     slug = slugify(prompt)
-    base_dir = Path(output_base_dir) if output_base_dir is not None else Path.cwd()
+    base_dir = (
+        Path(output_base_dir)
+        if output_base_dir is not None
+        else OUTPUTS_DIR.parent
+    )
     output_dir = base_dir / "outputs" / slug
     output_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- default to using the orchestrator outputs directory when running `run_story`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68655192dc008327b6ff1b68a2f0e072